### PR TITLE
Correct STDOUT and STDERR redirection

### DIFF
--- a/lib/silver_spurs/version.rb
+++ b/lib/silver_spurs/version.rb
@@ -1,3 +1,3 @@
 module SilverSpurs
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
- Turns out that dash doesn't understand that &> means to redirect
  STDOUT and STDERR to a file. Also, order matters, but not in a
  logical way.
- Version bump.
